### PR TITLE
Bump upper bounds for Stackage LTS 5.0

### DIFF
--- a/mqtt-hs.cabal
+++ b/mqtt-hs.cabal
@@ -25,15 +25,15 @@ library
   exposed-modules:     Network.MQTT, Network.MQTT.Parser, Network.MQTT.Encoding,
                        Network.MQTT.Types, Network.MQTT.Logger,
                        Network.MQTT.Monadic
-  build-depends:       base >=4.7 && <4.8,
+  build-depends:       base >=4.7 && <4.9,
                        mtl >=1.1 && <2.3,
                        transformers >=0.2 && <0.5,
-                       attoparsec >=0.10 && <0.13,
+                       attoparsec >=0.10 && <0.14,
                        bytestring >=0.10.2 && <0.11,
-                       text >=0.11.0.6 && <1.2,
+                       text >=0.11.0.6 && <1.3,
                        network >=2.0 && <2.7,
-                       singletons >=0.9 && < 1.1,
-                       monad-control >=0.3 && <0.4,
+                       singletons >=0.9 && <2.1,
+                       monad-control >=0.3 && <1.1,
                        monad-loops >=0.3 && <0.5
   default-language:    Haskell2010
 


### PR DESCRIPTION
I have NOT tested comprehensively whether the bump breaks anything. I have also not read what has changed in the dependencies. I have simply bumped the upper bounds.

Tentatively fixes #2.
