### PR TITLE
Updating the sample code that use TChan.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ A Haskell MQTT client library.
 A simple example, assuming a broker is running on localhost (needs -XOverloadedStrings):
 
 ```haskell
+{-# Language OverloadedStrings #-}
 import Network.MQTT
 import Network.MQTT.Logger
-Just mqtt <- connect defaultConfig { cLogger = warnings stdLogger }
-let f t payload = putStrLn $ "A message was published to " ++ show t ++ ": " ++ show payload
-subscribe mqtt NoConfirm "#" f
-publish mqtt Handshake False "some random/topic" "Some content!"
+import GHC.Conc.Sync
+import Control.Concurrent.STM
+
+main = do
+  mqtt <- connect defaultConfig { cLogger = warnings stdLogger }
+
+  -- Publish to the topic. 
+  publish mqtt Handshake False "random/topic" "this is the content"
+  
+  -- Subscribe to the topic.
+  let f (t, payload) = "A message was published to " ++ show t ++ ": " ++ show payload
+  subscribe mqtt NoConfirm "#" 
+  f <$> atomically (readTChan (messages mqtt))
 ```
 
 See the haddock for more documentation.


### PR DESCRIPTION
Hi,

I'm using version 0.3.0 for my application because the 0.2.0 can't be built on my environment. The dependency for `base` does not match. I felt confuse when to use 0.3.0 for the first time, because when I followed the sample code in README; it threw many errors, and honestly I'm a Haskell beginner. I scrutinized your source code and tried a few hours to make it works. Here's I update the README file, so another people doesn't need to spend many times to make the simple sample works.

P.S: when will you push the 0.3.0 to the Hackage?
