### PR TITLE
support ghc881, migrate to new singletons

### DIFF
--- a/Network/MQTT/Parser.hs
+++ b/Network/MQTT/Parser.hs
@@ -239,4 +239,4 @@ toQoS :: (Num a, Eq a, Show a, Monad m) => a -> m QoS
 toQoS 0 = return NoConfirm
 toQoS 1 = return Confirm
 toQoS 2 = return Handshake
-toQoS x = fail $ "Invalid QoS value: " ++ show x
+toQoS x = error $ "Invalid QoS value: " ++ show x

--- a/Network/MQTT/Types.hs
+++ b/Network/MQTT/Types.hs
@@ -60,22 +60,9 @@ module Network.MQTT.Types
   -- library, they are mostly used internally to get better guarantees
   -- about the flow of 'Message's.
   , toSMsgType
-  , SMsgType
+  , SMsgType(..)
   , withSomeSingI
-  , Sing( SCONNECT
-        , SCONNACK
-        , SPUBLISH
-        , SPUBACK
-        , SPUBREC
-        , SPUBREL
-        , SPUBCOMP
-        , SSUBSCRIBE
-        , SSUBACK
-        , SUNSUBSCRIBE
-        , SUNSUBACK
-        , SPINGREQ
-        , SPINGRESP
-        , SDISCONNECT)
+  , Sing
   ) where
 
 import Control.Exception (Exception)

--- a/mqtt-hs.cabal
+++ b/mqtt-hs.cabal
@@ -23,7 +23,7 @@ tested-with:         GHC==8.6.1, GHC==8.4.1, GHC==8.2.2, GHC==8.0.2
 library
   exposed-modules:     Network.MQTT, Network.MQTT.Parser, Network.MQTT.Encoding,
                        Network.MQTT.Types, Network.MQTT.Internal
-  build-depends:       base >=4.6 && <4.12,
+  build-depends:       base >=4.6 && <4.14,
                        async >=2.0 && <2.3,
                        mtl >=1.1 && <2.3,
                        transformers >=0.2 && <0.6,
@@ -31,7 +31,7 @@ library
                        bytestring >=0.10.2 && <0.11,
                        text >=0.11.0.6 && <1.3,
                        network >=2.0 && <2.9,
-                       singletons >=0.9 && < 2.6,
+                       singletons >=0.9 && <2.7,
                        stm >=2.4 && <2.6,
                        monad-loops >=0.3 && <0.5
   default-language:    Haskell2010


### PR DESCRIPTION
EmptyCase due to

Network/MQTT/Types.hs:289:1: error:
    Empty list of alternatives in case expression
      Use EmptyCase to allow this
    |
289 | singDecideInstance ''MsgType